### PR TITLE
Remove mysql JDBC driver

### DIFF
--- a/rmap-loader-deposit-disco/README.md
+++ b/rmap-loader-deposit-disco/README.md
@@ -46,7 +46,8 @@ JDBC url, e.g `jdbc:postgresql://localhost/test`.  By default, it uses a non-dur
 Supported JSBC drivers include:
 * sqlite.  This is especially useful for simply persisting to a file, without installing a RDBMS, e.g. `jdbc:sqlite:/path/to/rmap.db`
 * postgresql
-* mysql
+
+To use other JDBC drivers, add their jar to the classpath when running the deposit service jar, and specify an appropriate jdbc URI.
 
 ### `jdbc.username`
 

--- a/rmap-loader-deposit-disco/pom.xml
+++ b/rmap-loader-deposit-disco/pom.xml
@@ -191,14 +191,6 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>6.0.6</version>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
       <version>2.6.1</version>


### PR DESCRIPTION
MySQL JDBC driver is GPL, so this removes it from the default distribution.

Anybody who wants to use MySQL will need to specify a driver jar on the classpath