### PR TITLE
Added a registry to record run dates for harvester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <module>rmap-loader-api</module>
     <module>rmap-loader-jms</module>
     <module>rmap-loader-validation</module>
+    <module>rmap-loader-run-registry</module>
     <module>rmap-loader-util</module>
     <module>rmap-loader-transform-xsl</module>
     <module>rmap-loader-deposit-disco</module>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,9 @@
     <activemq.version>5.14.4</activemq.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
+    <sqllite.jdbc.version>3.16.1</sqllite.jdbc.version>
+    <postgresql.jdbc.version>42.0.0</postgresql.jdbc.version>
+    <hikaricp.version>2.6.1</hikaricp.version>
   </properties>
 
   <build>

--- a/rmap-loader-api/src/main/java/info/rmapproject/loader/HarvestRecordRegistry.java
+++ b/rmap-loader-api/src/main/java/info/rmapproject/loader/HarvestRecordRegistry.java
@@ -23,7 +23,7 @@ import info.rmapproject.loader.model.RecordInfo;
 /**
  * @author apb@jhu.edu
  */
-public interface HarvestRegistry {
+public interface HarvestRecordRegistry {
 
     public void register(RecordInfo info, URI discoURI);
 

--- a/rmap-loader-api/src/main/java/info/rmapproject/loader/HarvestRunRegistry.java
+++ b/rmap-loader-api/src/main/java/info/rmapproject/loader/HarvestRunRegistry.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software was produced as part of the RMap Project (http://rmap-project.info),
+ * The RMap Project was funded by the Alfred P. Sloan Foundation and is a 
+ * collaboration between Data Conservancy, Portico, and IEEE.
+ *******************************************************************************/
+package info.rmapproject.loader;
+
+import java.util.Date;
+
+/**
+ * Interface to support management of a registry to record run times of harvesting processes.
+ * 
+ * @author karen.hanson@jhu.edu
+ *
+ */
+
+public interface HarvestRunRegistry {
+
+	/**
+	 * Add a new run date for the loader name specified
+	 * @param loaderName lookup name for loader
+	 * @param date date run
+	 */
+    public void addRunDate(String loaderName, Date date);
+
+    /**
+     * Retrieve most recent run date for loader name specified
+     * @param loaderName lookup name for loader
+     * @return
+     */
+    public Date getLastRunDate(String loaderName);
+	
+}

--- a/rmap-loader-deposit-disco/pom.xml
+++ b/rmap-loader-deposit-disco/pom.xml
@@ -176,7 +176,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.16.1</version>
+      <version>${sqllite.jdbc.version}</version>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
@@ -184,7 +184,7 @@
      <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.0.0</version>
+      <version>${postgresql.jdbc.version}</version>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>2.6.1</version>
+      <version>${hikaricp.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/rmap-loader-deposit-disco/pom.xml
+++ b/rmap-loader-deposit-disco/pom.xml
@@ -75,7 +75,6 @@
 
   <dependencies>
 
-
     <dependency>
       <groupId>info.rmapproject</groupId>
       <artifactId>rmap-loader-api</artifactId>
@@ -178,14 +177,6 @@
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.16.1</version>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>42.0.0</version>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>

--- a/rmap-loader-deposit-disco/pom.xml
+++ b/rmap-loader-deposit-disco/pom.xml
@@ -180,7 +180,15 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
-
+    
+     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.0.0</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>

--- a/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/DiscoDepositConsumer.java
+++ b/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/DiscoDepositConsumer.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import info.rmapproject.loader.HarvestRecord;
 import info.rmapproject.loader.HarvestRecordStatus;
-import info.rmapproject.loader.HarvestRegistry;
+import info.rmapproject.loader.HarvestRecordRegistry;
 import info.rmapproject.loader.model.RecordInfo;
 
 /**
@@ -71,9 +71,9 @@ public class DiscoDepositConsumer implements Consumer<HarvestRecord> {
 
     private String authToken;
 
-    private HarvestRegistry harvestRegistry;
+    private HarvestRecordRegistry harvestRegistry;
 
-    public void setHarvestRegistry(HarvestRegistry registry) {
+    public void setHarvestRegistry(HarvestRecordRegistry registry) {
         this.harvestRegistry = registry;
     }
 
@@ -119,7 +119,6 @@ public class DiscoDepositConsumer implements Consumer<HarvestRecord> {
         }
 
         URI uri = rmapDiscoEndpoint;
-
         if (status.recordExists()) {
             uri = getUpdateURI(status.latest());
         }
@@ -130,7 +129,7 @@ public class DiscoDepositConsumer implements Consumer<HarvestRecord> {
 
         final HttpPost post = new HttpPost(uri);
         if (authToken != null) {
-            post.setHeader(AUTHORIZATION, "Basic: " + Base64.encodeBase64String(authToken.getBytes(UTF_8)));
+            post.setHeader(AUTHORIZATION, "Basic " + Base64.encodeBase64String(authToken.getBytes(UTF_8)));
         }
         post.setHeader(CONTENT_TYPE, contentType(record));
         post.setEntity(new ByteArrayEntity(record.getBody()));

--- a/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/DiscoDepositService.java
+++ b/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/DiscoDepositService.java
@@ -94,5 +94,6 @@ public class DiscoDepositService implements AutoCloseable {
     @Override
     public void close() throws Exception {
         jms.close();
+        
     }
 }

--- a/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/Main.java
+++ b/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/Main.java
@@ -40,7 +40,7 @@ public class Main {
         ds.setUsername(string("jdbc.username", null));
         ds.setPassword(string("jdbc.password", null));
 
-        final RdbmsHarvestRegistry harvestRegistry = new RdbmsHarvestRegistry();
+        final RdbmsHarvestRecordRegistry harvestRegistry = new RdbmsHarvestRecordRegistry();
         harvestRegistry.setDataSource(ds);
         harvestRegistry.init();
 

--- a/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistry.java
+++ b/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistry.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import info.rmapproject.loader.HarvestRecordStatus;
-import info.rmapproject.loader.HarvestRegistry;
+import info.rmapproject.loader.HarvestRecordRegistry;
 import info.rmapproject.loader.model.RecordInfo;
 
 /**
@@ -40,9 +40,9 @@ import info.rmapproject.loader.model.RecordInfo;
  *
  * @author apb@jhu.edu
  */
-public class RdbmsHarvestRegistry implements HarvestRegistry {
+public class RdbmsHarvestRecordRegistry implements HarvestRecordRegistry {
 
-    Logger LOG = LoggerFactory.getLogger(RdbmsHarvestRegistry.class);
+    Logger LOG = LoggerFactory.getLogger(RdbmsHarvestRecordRegistry.class);
 
     DataSource source;
 

--- a/rmap-loader-deposit-disco/src/test/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistryITest.java
+++ b/rmap-loader-deposit-disco/src/test/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistryITest.java
@@ -36,7 +36,7 @@ import info.rmapproject.loader.model.RecordInfo;
 /**
  * @author apb@jhu.edu
  */
-public class RdbmsHarvestRegistryITest {
+public class RdbmsHarvestRecordRegistryITest {
 
     @Rule
     public EmbeddedDatabaseRule dbRule = EmbeddedDatabaseRule
@@ -47,7 +47,7 @@ public class RdbmsHarvestRegistryITest {
     @Rule
     public TestName name = new TestName();
 
-    RdbmsHarvestRegistry toTest = new RdbmsHarvestRegistry();
+    RdbmsHarvestRecordRegistry toTest = new RdbmsHarvestRecordRegistry();
 
     @Before
     public void setUp() {
@@ -117,11 +117,11 @@ public class RdbmsHarvestRegistryITest {
     // This simply needs to not throw an exception to succeed;
     @Test
     public void DDLTest() {
-        final RdbmsHarvestRegistry second = new RdbmsHarvestRegistry();
+        final RdbmsHarvestRecordRegistry second = new RdbmsHarvestRecordRegistry();
         second.setDataSource(dbRule.getDataSource());
         second.init();
 
-        final RdbmsHarvestRegistry third = new RdbmsHarvestRegistry();
+        final RdbmsHarvestRecordRegistry third = new RdbmsHarvestRecordRegistry();
         third.setDataSource(dbRule.getDataSource());
         third.init();
     }

--- a/rmap-loader-integration/src/test/java/info/rmapproject/loader/integration/DiscoDepositConsumerIT.java
+++ b/rmap-loader-integration/src/test/java/info/rmapproject/loader/integration/DiscoDepositConsumerIT.java
@@ -39,7 +39,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import info.rmapproject.loader.HarvestRecord;
 import info.rmapproject.loader.HarvestRecordStatus;
-import info.rmapproject.loader.HarvestRegistry;
+import info.rmapproject.loader.HarvestRecordRegistry;
 import info.rmapproject.loader.deposit.disco.DiscoDepositConsumer;
 import info.rmapproject.loader.model.RecordInfo;
 
@@ -50,7 +50,7 @@ import info.rmapproject.loader.model.RecordInfo;
 public class DiscoDepositConsumerIT extends FakeRmap {
 
     @Mock
-    public HarvestRegistry harvestRegistry;
+    public HarvestRecordRegistry harvestRegistry;
 
     private static final String AUTH_TOKEN = "myToken";
 

--- a/rmap-loader-integration/src/test/java/info/rmapproject/loader/integration/RmapIT.java
+++ b/rmap-loader-integration/src/test/java/info/rmapproject/loader/integration/RmapIT.java
@@ -85,9 +85,10 @@ public class RmapIT extends FakeRmap {
 
     @Test
     public void unzipTest() throws Exception {
+        final File zipDir = new File(testDataDir, "zip");
         unzip = jar(new File(System.getProperty("zip.extract.jar")))
                 .logOutput(LoggerFactory.getLogger("extract-zip"))
-                .withEnv("input.directory", testDataDir.toString())
+                .withEnv("input.directory", zipDir.toString())
                 .withEnv("input.filename", "data.zip")
                 .withEnv("jms.queue.dest", "rmap.harvest.test-xml.fromZipFile")
                 .start();

--- a/rmap-loader-run-registry/README.md
+++ b/rmap-loader-run-registry/README.md
@@ -1,10 +1,10 @@
 # RMap Loader Run Registry
 
-The run registry is an optional tool that can be used to record and retrieve the most recent harvest date for a harvest run.  If used along side the [DiSCO deposit service](../rmap-loader/tree/master/rmap-loader-deposit-disco), the two will share a database. 
+The run registry is an optional tool that can be used to record and retrieve the most recent harvest date for a harvest run.  If used along side the [DiSCO deposit service](../rmap-loader-deposit-disco), the two will share a database. 
 
 ## Configuration and deployment
 
-As with the [DiSCO deposit service](../rmap-loader/tree/master/rmap-loader-deposit-disco), configuration is provided by using environment variables, or system properties (it doesn't matter which).   
+As with the [DiSCO deposit service](../rmap-loader-deposit-disco), configuration is provided by using environment variables, or system properties (it doesn't matter which).   
 
 ### `jdbc.url`
 

--- a/rmap-loader-run-registry/README.md
+++ b/rmap-loader-run-registry/README.md
@@ -1,0 +1,34 @@
+# RMap Loader Run Registry
+
+The run registry is an optional tool that can be used to record and retrieve the most recent harvest date for a harvest run.  If used along side the [DiSCO deposit service](rmap-loader/tree/master/rmap-loader-deposit-disco), the two will share a database. 
+
+## Configuration and deployment
+
+As with the [DiSCO deposit service](rmap-loader/tree/master/rmap-loader-deposit-disco), configuration is provided by using environment variables, or system properties (it doesn't matter which).   
+
+### `jdbc.url`
+
+JDBC url, e.g `jdbc:postgresql://localhost/test`.  By default, it uses a non-durable in-memory sqlite database. 
+
+Supported JDBC drivers include:
+* sqlite.  This is especially useful for simply persisting to a file, without installing a RDBMS, e.g. `jdbc:sqlite:/path/to/rmap.db`
+* postgresql
+
+To use other JDBC drivers, add their jar to the classpath when running the deposit service jar, and specify an appropriate jdbc URI.
+
+### `jdbc.username`
+
+RDBMS username
+
+### `jdbc.password`
+
+RDBMS password.
+
+### `LOG.*`
+
+Any environment variable or system property that begins with `LOG.` can be used to specify the logging level of 
+the logger whose name appears after the `LOG.` characters.  For example, setting the environment variable:
+
+    LOG.info.rmapproject=DEBUG
+    
+ This will set the logger called `info.rmapproject` to the `DEBUG` level. 

--- a/rmap-loader-run-registry/README.md
+++ b/rmap-loader-run-registry/README.md
@@ -1,10 +1,10 @@
 # RMap Loader Run Registry
 
-The run registry is an optional tool that can be used to record and retrieve the most recent harvest date for a harvest run.  If used along side the [DiSCO deposit service](rmap-loader/tree/master/rmap-loader-deposit-disco), the two will share a database. 
+The run registry is an optional tool that can be used to record and retrieve the most recent harvest date for a harvest run.  If used along side the [DiSCO deposit service](../rmap-loader/tree/master/rmap-loader-deposit-disco), the two will share a database. 
 
 ## Configuration and deployment
 
-As with the [DiSCO deposit service](rmap-loader/tree/master/rmap-loader-deposit-disco), configuration is provided by using environment variables, or system properties (it doesn't matter which).   
+As with the [DiSCO deposit service](../rmap-loader/tree/master/rmap-loader-deposit-disco), configuration is provided by using environment variables, or system properties (it doesn't matter which).   
 
 ### `jdbc.url`
 

--- a/rmap-loader-run-registry/README.md
+++ b/rmap-loader-run-registry/README.md
@@ -1,4 +1,4 @@
-# RMap Loader Run Registry
+# RMap loader run registry
 
 The run registry is an optional tool that can be used to record and retrieve the most recent harvest date for a harvest run.  If used along side the [DiSCO deposit service](../rmap-loader-deposit-disco), the two will share a database. 
 

--- a/rmap-loader-run-registry/pom.xml
+++ b/rmap-loader-run-registry/pom.xml
@@ -1,0 +1,76 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>info.rmapproject</groupId>
+    <artifactId>rmap-loader</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>rmap-loader-run-registry</artifactId>
+  <packaging>bundle</packaging>
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>info.rmapproject</groupId>
+      <artifactId>rmap-loader-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  
+    <dependency>
+      <groupId>info.rmapproject</groupId>
+      <artifactId>rmap-loader-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+   
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>2.6.1</version>
+      <optional>true</optional>
+    </dependency>
+    
+    <!-- for testing -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.zapodot</groupId>
+      <artifactId>embedded-db-junit</artifactId>
+      <version>1.0-RC1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.unitils</groupId>
+      <artifactId>unitils-core</artifactId>
+      <version>3.4.2</version>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    
+   </dependencies>
+</project>

--- a/rmap-loader-run-registry/pom.xml
+++ b/rmap-loader-run-registry/pom.xml
@@ -28,11 +28,27 @@
       <artifactId>rmap-loader-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-   
+    
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>${sqllite.jdbc.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    
+     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.jdbc.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>2.6.1</version>
+      <version>${hikaricp.version}</version>
       <optional>true</optional>
     </dependency>
     

--- a/rmap-loader-run-registry/src/main/java/info/rmapproject/loader/RdbmsHarvestRunRegistry.java
+++ b/rmap-loader-run-registry/src/main/java/info/rmapproject/loader/RdbmsHarvestRunRegistry.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.rmapproject.loader;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Date;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple optional RDBMS-based registry to record run dates for a harvester.
+ *
+ * @author karen.hanson@jhu.edu
+ */
+public class RdbmsHarvestRunRegistry implements HarvestRunRegistry {
+
+    Logger LOG = LoggerFactory.getLogger(RdbmsHarvestRunRegistry.class);
+
+    DataSource source;
+
+    public void setDataSource(DataSource source) {
+        this.source = source;
+    }
+
+    public void init() {
+        try (Connection conn = source.getConnection()) {
+            try (Statement statement = conn.createStatement()) {
+            	boolean createTable = true;
+            	
+            	statement.execute("SHOW TABLES");
+            	ResultSet rs = statement.getResultSet();
+            	while (rs.next()){
+            		if (rs.getString(1).toUpperCase().equals("LOADERRUN")) {
+            			createTable=false;
+            			break;
+            		}
+            	}
+
+                if (createTable) {
+                	statement.execute("CREATE TABLE IF NOT EXISTS loaderRun (name VARCHAR(255) NOT NULL, runDate BIGINT NOT NULL)");
+                    statement.execute("CREATE INDEX name_idx ON loaderRun (name)");
+                }
+
+            }
+
+        } catch (final SQLException e) {
+            throw new RuntimeException("Could not create tables", e);
+        }
+
+    }
+
+    @Override
+    public void addRunDate(String name, Date runDate) {
+
+        if (name == null || name.length()==0 ||runDate == null) {
+            LOG.debug("Empty name or runDate parameter. Cannot add run date.");
+            throw new IllegalArgumentException("Name and runDate parameter required to add a run date");
+        }
+        try (Connection conn = source.getConnection()) {
+            final PreparedStatement insertRecord = conn.prepareStatement(
+                    "INSERT INTO loaderRun (name, runDate) VALUES (?, ?)");
+
+            insertRecord.setString(1, name.toString());
+            insertRecord.setLong(2, runDate.getTime());
+
+            if (insertRecord.executeUpdate() < 1) {
+                throw new RuntimeException("Record did not insert into registry");
+            }
+
+        } catch (final SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @Override
+    public Date getLastRunDate(String name) {
+
+    	Date lastRunDate = null;
+    	
+        if (name == null || name.length()==0 ) {
+            LOG.debug("Empty name parameter. Cannot retrieve last run date.");
+            throw new IllegalArgumentException("Name parameter required to retrieve last run date");
+        }
+
+        try (Connection conn = source.getConnection()) {
+            final PreparedStatement findRecord = conn.prepareStatement(
+                    "SELECT runDate FROM loaderRun WHERE name = ? ORDER BY runDate DESC LIMIT 1");
+            findRecord.setString(1, name);
+            
+            try (ResultSet results = findRecord.executeQuery()) {
+	                if (results.next()) {
+	                	lastRunDate = new Date(results.getLong(1));
+	                }
+	            }
+	     } catch (final SQLException e) {
+	         throw new RuntimeException(e);
+	     }
+
+        return lastRunDate;
+    }
+
+}

--- a/rmap-loader-run-registry/src/main/resources/logback.xml
+++ b/rmap-loader-run-registry/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%p %d{HH:mm:ss.SSS} \(%c{28}\) %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="info.rmapproject" additivity="false" level="INFO">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
+  <root additivity="false" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/rmap-loader-run-registry/src/test/java/info/rmapproject/loader/RdbmsHarvestRunRegistryITest.java
+++ b/rmap-loader-run-registry/src/test/java/info/rmapproject/loader/RdbmsHarvestRunRegistryITest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.rmapproject.loader;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.zapodot.junit.db.EmbeddedDatabaseRule;
+import org.zapodot.junit.db.EmbeddedDatabaseRule.CompatibilityMode;
+
+/**
+ * Tests for RdbmsHarvestRunRegistry
+ * @author karen.hanson@jhu.edu
+ */
+public class RdbmsHarvestRunRegistryITest {
+
+    @Rule
+    public EmbeddedDatabaseRule dbRule = EmbeddedDatabaseRule
+            .builder()
+            .withMode(CompatibilityMode.PostgreSQL)
+            .build();
+
+    @Rule
+    public TestName name = new TestName();
+
+    RdbmsHarvestRunRegistry toTest = new RdbmsHarvestRunRegistry();
+
+    @Before
+    public void setUp() {
+        toTest.setDataSource(dbRule.getDataSource());
+        toTest.init();
+    }
+
+    @Test
+    public void noPreviousRunsLastRunDateNull() {
+    	String runName ="test name";
+        final Date lastRunDate = toTest.getLastRunDate(runName);
+        assertTrue(lastRunDate==null);
+    }
+
+    @Test
+    public void createRunDatesAndRetrieveLatest() {
+    	try {
+	    	String runName ="test name";
+	    	Date date1 = new Date();
+	    	toTest.addRunDate(runName, date1);
+	    	Thread.sleep(1000);
+	    	
+	    	Date date2 = new Date();
+	    	toTest.addRunDate(runName, date2);
+	    	
+	    	Date lastRunDate = toTest.getLastRunDate(runName);
+	    	
+	    	assertTrue(lastRunDate.equals(date2));
+	    	
+	    	
+    	} catch (Exception ex) {
+    		ex.printStackTrace();
+    		fail("An error occured during Test: createRunDatesAndRetrieveLatest()");
+    	}
+    	
+    	
+    }
+
+
+    // This simply needs to not throw an exception to succeed;
+    @Test
+    public void DDLTest() {
+        final RdbmsHarvestRunRegistry second = new RdbmsHarvestRunRegistry();
+        second.setDataSource(dbRule.getDataSource());
+        second.init();
+
+        final RdbmsHarvestRunRegistry third = new RdbmsHarvestRunRegistry();
+        third.setDataSource(dbRule.getDataSource());
+        third.init();
+    }
+
+}

--- a/rmap-loader-run-registry/src/test/resources/logback-test.xml
+++ b/rmap-loader-run-registry/src/test/resources/logback-test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2017 Johns Hopkins University ~ ~ Licensed under the Apache 
+  License, Version 2.0 (the "License"); ~ you may not use this file except 
+  in compliance with the License. ~ You may obtain a copy of the License at 
+  ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by applicable 
+  law or agreed to in writing, software ~ distributed under the License is 
+  distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+  KIND, either express or implied. ~ See the License for the specific language 
+  governing permissions and ~ limitations under the License. -->
+
+<!DOCTYPE configuration>
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+
+    <encoder>
+
+      <pattern>%p %d{HH:mm:ss.SSS} \(%c{0}\) %m%n</pattern>
+
+    </encoder>
+
+  </appender>
+
+
+  <logger name="org.apache.activemq" additivity="false" level="${apache.log:-DEBUG}">
+
+    <appender-ref ref="STDOUT" />
+
+  </logger>
+  
+  <logger name="info.rmapproject" additivity="false" level="${rmap.log:-DEBUG}">
+
+    <appender-ref ref="STDOUT" />
+
+  </logger>
+
+
+  <root additivity="false" level="INFO">
+
+    <appender-ref ref="STDOUT" />
+
+  </root>
+
+</configuration>


### PR DESCRIPTION
This change is to add an optional utility that can be used directly by harvester apps to log a new run date and retrieve the most recent run date.  It shares the database connection with the HarvestRegistry.  To avoid confusion in the library names, the original HarvestRegistry has been renamed to HarvestRecordRegistry, and the new class is HarvestRunRegistry.