### PR TITLE
Fixes to DiSCO update logic

### DIFF
--- a/rmap-loader-api/src/main/java/info/rmapproject/loader/HarvestRecordStatus.java
+++ b/rmap-loader-api/src/main/java/info/rmapproject/loader/HarvestRecordStatus.java
@@ -27,7 +27,7 @@ public class HarvestRecordStatus {
 
     boolean recordExists = false;
 
-    boolean isLatest = false;
+    boolean isUpToDate = false;
 
     URI latest;
 
@@ -39,12 +39,12 @@ public class HarvestRecordStatus {
         this.recordExists = exists;
     }
 
-    public boolean isLatest() {
-        return isLatest;
+    public boolean isUpToDate() {
+        return isUpToDate;
     }
 
-    public void setIsLatest(boolean isLatest) {
-        this.isLatest = isLatest;
+    public void setIsUpToDate(boolean isUpToDate) {
+        this.isUpToDate = isUpToDate;
     }
 
     public URI latest() {

--- a/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/Main.java
+++ b/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/Main.java
@@ -61,6 +61,6 @@ public class Main {
 
     private static URI makeDiscoEndpointUri() {
         return URI.create(string("rmap.api.baseuri",
-                "https://test.rmap-project.org/apitest/").replaceFirst("/$", "") + "/discos/");
+                "https://test.rmap-hub.org/api/").replaceFirst("/$", "") + "/discos/");
     }
 }

--- a/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistry.java
+++ b/rmap-loader-deposit-disco/src/main/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistry.java
@@ -114,9 +114,10 @@ public class RdbmsHarvestRecordRegistry implements HarvestRecordRegistry {
                 if (results.next()) {
                     status.setRecordExists(true);
                     status.setLatest(URI.create(results.getString(1)));
-                    status.setIsLatest(date(info) >= results.getLong(2));
+                    status.setIsUpToDate(date(info) <= results.getLong(2));
                 } else {
                     status.setRecordExists(false);
+                    status.setIsUpToDate(false);
                 }
             }
         } catch (final SQLException e) {

--- a/rmap-loader-deposit-disco/src/test/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistryITest.java
+++ b/rmap-loader-deposit-disco/src/test/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistryITest.java
@@ -78,40 +78,52 @@ public class RdbmsHarvestRecordRegistryITest {
 
         final HarvestRecordStatus status = toTest.getStatus(info);
         assertTrue(status.recordExists());
-        assertTrue(status.isLatest());
+        assertTrue(status.isUpToDate());
         assertEquals(discoUri, status.latest());
     }
 
     @Test
-    public void latestRecordTest() {
+    public void isUpToDateRecordTest() {
         final URI recordId = URI.create("http://record-id");
 
-        final URI oldDiscoUri = URI.create("http://disco-uri/" + name.getMethodName() + "/old");
-        final URI newDiscoUri = URI.create("http://disco-uri/" + name.getMethodName() + "/new");
+        final URI v1DiscoUri = URI.create("http://disco-uri/" + name.getMethodName() + "/v1");
+        final URI v2DiscoUri = URI.create("http://disco-uri/" + name.getMethodName() + "/v2");
 
-        final Date oldDate = new Date(1000000);
-        final Date newDate = new Date(2000000);
+        final Date v1Date = new Date(1000000);
+        final Date v2Date = new Date(2000000);
+        final Date v3Date = new Date(3000000);
 
-        final RecordInfo oldRecordInfo = new RecordInfo();
-        oldRecordInfo.setId(recordId);
-        oldRecordInfo.setDate(oldDate);
+        final RecordInfo v1RecordInfo = new RecordInfo();
+        v1RecordInfo.setId(recordId);
+        v1RecordInfo.setDate(v1Date);
 
-        final RecordInfo newRecordInfo = new RecordInfo();
-        newRecordInfo.setId(recordId);
-        newRecordInfo.setDate(newDate);
+        final RecordInfo v2RecordInfo = new RecordInfo();
+        v2RecordInfo.setId(recordId);
+        v2RecordInfo.setDate(v2Date);
 
-        toTest.register(newRecordInfo, newDiscoUri);
-        toTest.register(oldRecordInfo, oldDiscoUri);
+        final RecordInfo v3RecordInfo = new RecordInfo();
+        v3RecordInfo.setId(recordId);
+        v3RecordInfo.setDate(v3Date);
+        
+        toTest.register(v2RecordInfo, v2DiscoUri);
+        toTest.register(v1RecordInfo, v1DiscoUri);
 
-        final HarvestRecordStatus oldStatus = toTest.getStatus(oldRecordInfo);
-        assertTrue(oldStatus.recordExists());
-        assertFalse(oldStatus.isLatest());
-        assertEquals(newDiscoUri, oldStatus.latest());
+        final HarvestRecordStatus v1Status = toTest.getStatus(v1RecordInfo);
+        assertTrue(v1Status.recordExists());
+        assertTrue(v1Status.isUpToDate()); // comparing to old data should show it's already up to date
+        assertEquals(v2DiscoUri, v1Status.latest());
 
-        final HarvestRecordStatus newStatus = toTest.getStatus(newRecordInfo);
-        assertTrue(newStatus.recordExists());
-        assertTrue(newStatus.isLatest());
-        assertEquals(newDiscoUri, newStatus.latest());
+        final HarvestRecordStatus v2Status = toTest.getStatus(v2RecordInfo);
+        assertTrue(v2Status.recordExists());
+        assertTrue(v2Status.isUpToDate()); // comparing to new data also shows it's already up to date
+        assertEquals(v2DiscoUri, v2Status.latest());
+
+        //new info not yet recorded, so it should know the registry is not up to date compared to this new record info
+        final HarvestRecordStatus v3Status = toTest.getStatus(v3RecordInfo);
+        assertTrue(v3Status.recordExists());
+        assertFalse(v3Status.isUpToDate()); // comparing to new data also shows it's already up to date
+        assertEquals(v2DiscoUri, v3Status.latest());
+        
     }
 
     // This simply needs to not throw an exception to succeed;

--- a/rmap-loader-deposit-disco/src/test/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistryITest.java
+++ b/rmap-loader-deposit-disco/src/test/java/info/rmapproject/loader/deposit/disco/RdbmsHarvestRecordRegistryITest.java
@@ -121,7 +121,7 @@ public class RdbmsHarvestRecordRegistryITest {
         //new info not yet recorded, so it should know the registry is not up to date compared to this new record info
         final HarvestRecordStatus v3Status = toTest.getStatus(v3RecordInfo);
         assertTrue(v3Status.recordExists());
-        assertFalse(v3Status.isUpToDate()); // comparing to new data also shows it's already up to date
+        assertFalse(v3Status.isUpToDate()); // comparing to even newer data now shows it is not up to date.
         assertEquals(v2DiscoUri, v3Status.latest());
         
     }

--- a/rmap-loader-integration/src/test/java/info/rmapproject/loader/integration/DiscoDepositConsumerIT.java
+++ b/rmap-loader-integration/src/test/java/info/rmapproject/loader/integration/DiscoDepositConsumerIT.java
@@ -109,7 +109,7 @@ public class DiscoDepositConsumerIT extends FakeRmap {
         final HarvestRecordStatus status = new HarvestRecordStatus();
         status.setRecordExists(true);
         status.setLatest(OLD_DISCO_URI);
-        status.setIsLatest(false);
+        status.setIsUpToDate(false);
 
         when(harvestRegistry.getStatus(any(RecordInfo.class))).thenReturn(status);
 
@@ -152,7 +152,7 @@ public class DiscoDepositConsumerIT extends FakeRmap {
     public void skipUpToDateTest() {
         final HarvestRecordStatus status = new HarvestRecordStatus();
         status.setRecordExists(true);
-        status.setIsLatest(true);
+        status.setIsUpToDate(true);
         when(harvestRegistry.getStatus(any())).thenReturn(status);
 
         final HarvestRecord record = new HarvestRecord();

--- a/rmap-loader-jms/src/test/java/info/rmapproject/loader/jms/HarvestRecordWriterTest.java
+++ b/rmap-loader-jms/src/test/java/info/rmapproject/loader/jms/HarvestRecordWriterTest.java
@@ -71,12 +71,11 @@ public class HarvestRecordWriterTest {
             final CountDownLatch messageReceived = new CountDownLatch(1);
 
             jms.listen(queue, onHarvestRecord(received -> {
-                messageReceived.countDown();
                 receivedRecord.set(received);
+                messageReceived.countDown();
             }));
-
+            
             assertTrue(messageReceived.await(10, TimeUnit.SECONDS));
-            TimeUnit.SECONDS.sleep(3);
             assertReflectionEquals(record, receivedRecord.get(), ReflectionComparatorMode.LENIENT_ORDER);
 
         }

--- a/rmap-loader-jms/src/test/java/info/rmapproject/loader/jms/HarvestRecordWriterTest.java
+++ b/rmap-loader-jms/src/test/java/info/rmapproject/loader/jms/HarvestRecordWriterTest.java
@@ -76,6 +76,7 @@ public class HarvestRecordWriterTest {
             }));
 
             assertTrue(messageReceived.await(10, TimeUnit.SECONDS));
+            TimeUnit.SECONDS.sleep(3);
             assertReflectionEquals(record, receivedRecord.get(), ReflectionComparatorMode.LENIENT_ORDER);
 
         }
@@ -93,7 +94,7 @@ public class HarvestRecordWriterTest {
 
             final CountDownLatch errorReceived = new CountDownLatch(1);
             writer.write(queue, record);
-            TimeUnit.SECONDS.sleep(3);
+            
             // Throw an error upon listen. Register an error handler that directs to the error queue.
             jms.listen(queue, onHarvestRecord(received -> {
                 throw new RuntimeException("processing failed");

--- a/rmap-loader-jms/src/test/java/info/rmapproject/loader/jms/HarvestRecordWriterTest.java
+++ b/rmap-loader-jms/src/test/java/info/rmapproject/loader/jms/HarvestRecordWriterTest.java
@@ -93,7 +93,7 @@ public class HarvestRecordWriterTest {
 
             final CountDownLatch errorReceived = new CountDownLatch(1);
             writer.write(queue, record);
-
+            TimeUnit.SECONDS.sleep(3);
             // Throw an error upon listen. Register an error handler that directs to the error queue.
             jms.listen(queue, onHarvestRecord(received -> {
                 throw new RuntimeException("processing failed");


### PR DESCRIPTION
The way isLatest() was being used caused DiSCOs never to update, partly because of the ambiguity of what HarvestRecordStatus.isLatest(RecordInfo) means - whether it means the record in the registry isLatest, or the new RecordInfo isLatest.
So, previously isLatest() was set to true when the harvested RecordInfo passed in was newer than the the version listed in the RecordRegistry.  Now, isLatest has been renamed to isUpToDate(), and it is true when the record in the registry isUpToDate.  If the registry indicates the record isUpToDate, the newly harvested RecordInfo does not need to be processed. New logic reflects this and DiSCO updates work as expected. An integration test that simulates a DiSCO being harvested 3 times demonstrates the behavior.
Also implemented a minor path correction for DiSCO updates, where the full API URL was recorded as the DiSCO URI, rather than just e.g. rmap:fjskj2dk
Fixed integration tests to reflect these changes.