### PR TITLE
Add method that does basic comparison of two DiSCOs to see if they're identical

### DIFF
--- a/rmap-loader-validation/src/main/java/info/rmapproject/loader/validation/DiscoValidator.java
+++ b/rmap-loader-validation/src/main/java/info/rmapproject/loader/validation/DiscoValidator.java
@@ -30,105 +30,105 @@ import org.apache.jena.rdf.model.Statement;
 
 public class DiscoValidator {
 
-    static final String DCTERMS_NS = "http://purl.org/dc/terms/";
+	static final String DCTERMS_NS = "http://purl.org/dc/terms/";
 
-    static final String RMAP_NS = "http://rmap-project.org/rmap/terms/";
+	static final String RMAP_NS = "http://rmap-project.org/rmap/terms/";
 
-    static final String ORE_NS = "http://www.openarchives.org/ore/terms/";
+	static final String ORE_NS = "http://www.openarchives.org/ore/terms/";
 
-    static final String RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+	static final String RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 
-    public static void validate(InputStream rdf, Format format) {
-        final Model model = ModelFactory.createDefaultModel();
-        model.read(rdf, "", format.toString());
+	public static void validate(InputStream rdf, Format format) {
+		final Model model = ModelFactory.createDefaultModel();
+		model.read(rdf, "", format.toString());
 
-        final List<Statement> discoResources =
-                cut(model,
-                        new SimpleSelector(null, model.getProperty(RDF_NS + "type"), model.getResource(RMAP_NS +
-                                "DiSCO")))
-                                        .listStatements().toList();
+		final List<Statement> discoResources =
+				cut(model,
+						new SimpleSelector(null, model.getProperty(RDF_NS + "type"), model.getResource(RMAP_NS +
+								"DiSCO")))
+				.listStatements().toList();
 
-        if (discoResources.size() != 1) {
-            throw new ValidationException("Wrong number of DiSCO resources.  Should be 1, is " + discoResources
-                    .size());
-        }
+		if (discoResources.size() != 1) {
+			throw new ValidationException("Wrong number of DiSCO resources.  Should be 1, is " + discoResources
+					.size());
+		}
 
-        final Model discoTriples = cut(model, new SimpleSelector(discoResources.get(0).getSubject(), null,
-                (RDFNode) null));
+		final Model discoTriples = cut(model, new SimpleSelector(discoResources.get(0).getSubject(), null,
+				(RDFNode) null));
 
-        /* Any number of creators, so we don't care */
-        cut(discoTriples, new SimpleSelector(null, discoTriples.getProperty(DCTERMS_NS + "creator"), (RDFNode) null));
+		/* Any number of creators, so we don't care */
+		cut(discoTriples, new SimpleSelector(null, discoTriples.getProperty(DCTERMS_NS + "creator"), (RDFNode) null));
 
-        /* Zero or one descriptions */
-        if (1 < cut(discoTriples,
-                new SimpleSelector(null, discoTriples.getProperty(DCTERMS_NS + "description"), (RDFNode) null))
-                        .listStatements().toList().size()) {
-            throw new ValidationException("More than one description detected");
-        }
+		/* Zero or one descriptions */
+		if (1 < cut(discoTriples,
+				new SimpleSelector(null, discoTriples.getProperty(DCTERMS_NS + "description"), (RDFNode) null))
+				.listStatements().toList().size()) {
+			throw new ValidationException("More than one description detected");
+		}
 
-        /* The rest need to be aggregated resources */
-        final List<Resource> aggregatedResources =
-                cut(discoTriples,
-                        new SimpleSelector(null, discoTriples.getProperty(ORE_NS + "aggregates"), (RDFNode) null))
-                                .listObjects().mapWith(n -> n.asResource()).filterKeep(r -> {
-                                    if (r.isAnon()) {
-                                        throw new ValidationException("Cannot aggregate blank nodes");
-                                    }
-                                    return true;
-                                }).toList();
+		/* The rest need to be aggregated resources */
+		final List<Resource> aggregatedResources =
+				cut(discoTriples,
+						new SimpleSelector(null, discoTriples.getProperty(ORE_NS + "aggregates"), (RDFNode) null))
+				.listObjects().mapWith(n -> n.asResource()).filterKeep(r -> {
+					if (r.isAnon()) {
+						throw new ValidationException("Cannot aggregate blank nodes");
+					}
+					return true;
+				}).toList();
 
-        /* Make sure DiSCO resource triples have been exhausted */
-        if (!discoTriples.isEmpty()) {
-            final StringWriter writer = new StringWriter();
-            discoTriples.write(writer, "N-TRIPLE");
-            throw new ValidationException("DiSCO has extra triples " + writer.toString());
-        }
+		/* Make sure DiSCO resource triples have been exhausted */
+		if (!discoTriples.isEmpty()) {
+			final StringWriter writer = new StringWriter();
+			discoTriples.write(writer, "N-TRIPLE");
+			throw new ValidationException("DiSCO has extra triples " + writer.toString());
+		}
 
-        /* Remove all triples with our aggregated resources as subject */
-        for (final Resource aggregated : aggregatedResources) {
-            removeTree(aggregated, model);
-        }
+		/* Remove all triples with our aggregated resources as subject */
+		for (final Resource aggregated : aggregatedResources) {
+			removeTree(aggregated, model);
+		}
 
-        /* Now verify that there are none left */
-        if (!model.isEmpty()) {
-            final StringWriter writer = new StringWriter();
-            model.write(writer, "N-TRIPLE");
-            throw new ValidationException("Unconnected triples found" + writer.toString());
-        }
-    }
-    
-    
-    /**
-     * Compares two sets of RDF passed in to determine whether they are different, and therefore an update is required.
-     * TODO: doesn't currently work for BNODES that aren't DiSCO ID
-     * @param rmapRdf
-     * @param newRdf
-     * @param format
-     * @return true if different
-     */
+		/* Now verify that there are none left */
+		if (!model.isEmpty()) {
+			final StringWriter writer = new StringWriter();
+			model.write(writer, "N-TRIPLE");
+			throw new ValidationException("Unconnected triples found" + writer.toString());
+		}
+	}
+
+
+	/**
+	 * Compares two sets of RDF passed in to determine whether they are different, and therefore an update is required.
+	 * TODO: doesn't currently work for BNODES that aren't DiSCO ID
+	 * @param rmapRdf
+	 * @param newRdf
+	 * @param format
+	 * @return true if different
+	 */
 	public static boolean different(InputStream rmapRdf, InputStream newRdf, Format format) {
-        final Model rmapModel = ModelFactory.createDefaultModel();
-        rmapModel.read(rmapRdf, "", format.toString());
-        
-        final Model newModel = ModelFactory.createDefaultModel();
-        newModel.read(newRdf, "", format.toString());
-                 
-        Selector idSelector = new SimpleSelector(null, rmapModel.getProperty(RDF_NS + "type"), rmapModel.getResource(RMAP_NS + "DiSCO"));
+		final Model rmapModel = ModelFactory.createDefaultModel();
+		rmapModel.read(rmapRdf, "", format.toString());
 
-        Resource rmapDiscoUri = rmapModel.listStatements(idSelector).toList().get(0).getSubject();
+		final Model newModel = ModelFactory.createDefaultModel();
+		newModel.read(newRdf, "", format.toString());
+
+		Selector idSelector = new SimpleSelector(null, rmapModel.getProperty(RDF_NS + "type"), rmapModel.getResource(RMAP_NS + "DiSCO"));
+
+		Resource rmapDiscoUri = rmapModel.listStatements(idSelector).toList().get(0).getSubject();
 		Selector discoPropsSelector = new SimpleSelector(rmapDiscoUri, null, (RDFNode) null);
-        List<Statement> rmapDiscoStmts = rmapModel.listStatements(discoPropsSelector).toList();
+		List<Statement> rmapDiscoStmts = rmapModel.listStatements(discoPropsSelector).toList();
 
-        Resource newDiscoUri = newModel.listStatements(idSelector).toList().get(0).getSubject();
-        
-        Model newStmts = newModel.difference(rmapModel);
-                
-        for (Statement stmt : rmapDiscoStmts){
-        	newStmts = remove(newStmts, new SimpleSelector(newDiscoUri, stmt.getPredicate(), stmt.getObject()));
-        	newStmts = remove(newStmts, new SimpleSelector(rmapDiscoUri, stmt.getPredicate(), stmt.getObject()));        	
-        }
-        
-        /*
+		Resource newDiscoUri = newModel.listStatements(idSelector).toList().get(0).getSubject();
+
+		Model newStmts = newModel.difference(rmapModel);
+
+		for (Statement stmt : rmapDiscoStmts){
+			newStmts = remove(newStmts, new SimpleSelector(newDiscoUri, stmt.getPredicate(), stmt.getObject()));
+			newStmts = remove(newStmts, new SimpleSelector(rmapDiscoUri, stmt.getPredicate(), stmt.getObject()));        	
+		}
+
+		/*
         if (newStmts.size()>0) {
         	//still some differences
         	for (Statement stmt : newStmts.listStatements().toList()){
@@ -137,76 +137,77 @@ public class DiscoValidator {
         		}
         	}        	
         }
-        */
-        
-        if (newStmts.size()>0){
-        	return true;
-        } else {
-        	return false;
-        }
+		 */
+
+		if (newStmts.size()>0){
+			return true;
+		} else {
+			return false;
+		}
 	}
-    
-
-    static void removeTree(Resource resource, Model model) {
-        cut(model, new SimpleSelector(resource, null, (RDFNode) null)).listObjects().filterKeep(o -> o.isResource())
-                .mapWith(RDFNode::asResource).forEachRemaining(r -> removeTree(r, model));
-    }
-
-    public enum Format {
-        TURTLE("TTL"), RDF_XML("RDF/XML");
-
-        final String jena_name;
-
-        Format(String name) {
-            jena_name = name;
-        }
-
-        @Override
-        public String toString() {
-            return jena_name;
-        }
-    }
-
-    @SuppressWarnings("serial")
-    public static class ValidationException
-            extends RuntimeException {
-
-        public ValidationException(String msg) {
-            super(msg);
-        }
-    }
-
-    /**
-     * Remove and return a subset of a Model with the given Selector.
-     *
-     * @param from Model that will have statements removed
-     * @param selector Selector for matching statements to remove
-     * @return a Model containing all the extracted triples.
-     */
-    public static Model cut(Model from, Selector selector) {
-
-        final Model excised = ModelFactory.createDefaultModel();
-        final List<Statement> toRemove = from.listStatements(selector).toList();
-
-        excised.add(toRemove);
-        from.remove(toRemove);
-
-        return excised;
-    }
 
 
-    /**
-     *
-     * @param from Model that will have statements removed
-     * @param selector Selector for matching statements to remove
-     * @return a Model containing all the extracted triples.
-     */
-    public static Model remove(Model from, Selector selector) {
-        final List<Statement> toRemove = from.listStatements(selector).toList();
-        from.remove(toRemove);
-        return from;
-    }
-    
-    
-    
+	static void removeTree(Resource resource, Model model) {
+		cut(model, new SimpleSelector(resource, null, (RDFNode) null)).listObjects().filterKeep(o -> o.isResource())
+		.mapWith(RDFNode::asResource).forEachRemaining(r -> removeTree(r, model));
+	}
+
+	public enum Format {
+		TURTLE("TTL"), RDF_XML("RDF/XML");
+
+		final String jena_name;
+
+		Format(String name) {
+			jena_name = name;
+		}
+
+		@Override
+		public String toString() {
+			return jena_name;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class ValidationException
+	extends RuntimeException {
+
+		public ValidationException(String msg) {
+			super(msg);
+		}
+	}
+
+	/**
+	 * Remove and return a subset of a Model with the given Selector.
+	 *
+	 * @param from Model that will have statements removed
+	 * @param selector Selector for matching statements to remove
+	 * @return a Model containing all the extracted triples.
+	 */
+	public static Model cut(Model from, Selector selector) {
+
+		final Model excised = ModelFactory.createDefaultModel();
+		final List<Statement> toRemove = from.listStatements(selector).toList();
+
+		excised.add(toRemove);
+		from.remove(toRemove);
+
+		return excised;
+	}
+
+
+	/**
+	 * Remove a subset of a Model with the given Selector and return the rest.
+	 *
+	 * @param from Model that will have statements removed
+	 * @param selector Selector for matching statements to remove
+	 * @return a Model containing all the extracted triples.
+	 */
+	public static Model remove(Model from, Selector selector) {
+		final List<Statement> toRemove = from.listStatements(selector).toList();
+		from.remove(toRemove);
+		return from;
+	}
+
+
+
 }

--- a/rmap-loader-validation/src/main/java/info/rmapproject/loader/validation/DiscoValidator.java
+++ b/rmap-loader-validation/src/main/java/info/rmapproject/loader/validation/DiscoValidator.java
@@ -97,7 +97,6 @@ public class DiscoValidator {
 		}
 	}
 
-
 	/**
 	 * Compares two sets of RDF passed in to determine whether they are different, and therefore an update is required.
 	 * TODO: doesn't currently work for BNODES that aren't DiSCO ID
@@ -129,14 +128,14 @@ public class DiscoValidator {
 		}
 
 		/*
-        if (newStmts.size()>0) {
-        	//still some differences
-        	for (Statement stmt : newStmts.listStatements().toList()){
-        		if (stmt.getSubject() instanceof AnonId) {
-                	//check for non-bnode version        			
-        		}
-        	}        	
-        }
+		if (newStmts.size()>0) {
+			//still some differences
+			for (Statement stmt : newStmts.listStatements().toList()){
+				if (stmt.getSubject() instanceof AnonId) {
+				//check for non-bnode version        			
+				}
+			}        	
+		}
 		 */
 
 		if (newStmts.size()>0){
@@ -145,7 +144,6 @@ public class DiscoValidator {
 			return false;
 		}
 	}
-
 
 	static void removeTree(Resource resource, Model model) {
 		cut(model, new SimpleSelector(resource, null, (RDFNode) null)).listObjects().filterKeep(o -> o.isResource())
@@ -194,7 +192,6 @@ public class DiscoValidator {
 		return excised;
 	}
 
-
 	/**
 	 * Remove a subset of a Model with the given Selector and return the rest.
 	 *
@@ -207,7 +204,5 @@ public class DiscoValidator {
 		from.remove(toRemove);
 		return from;
 	}
-
-
 
 }


### PR DESCRIPTION
Provides optional validation method to check whether two DiSCOs are the same. This can be used to prevent DiSCO updates that repeatedly POST the same unchanged DiSCO to RMap as a new version. The comparison is fairly rudimentary - it has been manually tested, but needs unit tests. The DiSCO URI is ignored in the comparison. It will not work if there are any BNodes in the graph apart from the DiSCO URI since RMap removes these and replaces them with persistent identifiers.